### PR TITLE
adding short logic after cummulative return calculation

### DIFF
--- a/app/services/holding.py
+++ b/app/services/holding.py
@@ -101,7 +101,7 @@ def get_holding_summary(request: HoldingRequest) -> dict[str, any]:
         connection=engine,
     )["max"].item()
 
-    side = shares.sign()
+    side = stk["shares"].sign()
 
     n_days = len(df_wide["date"].unique())
 

--- a/app/services/holding.py
+++ b/app/services/holding.py
@@ -101,7 +101,7 @@ def get_holding_summary(request: HoldingRequest) -> dict[str, any]:
         connection=engine,
     )["max"].item()
 
-    side = stk["shares"].sign()
+    side = stk["shares"].sign().last()
 
     n_days = len(df_wide["date"].unique())
 
@@ -121,7 +121,7 @@ def get_holding_summary(request: HoldingRequest) -> dict[str, any]:
     value = shares * price
     volatility = stk["return"].std() * (n_days**0.5) * 100
     dividends = side * (stk["dividends"].sum())
-    dividends_per_share = side * (stk["dividends_per_share"].sum)
+    dividends_per_share = side * (stk["dividends_per_share"].sum())
     dividend_yield = dividends / value * 100
 
     min_date = stk["date"].min()

--- a/app/services/holding.py
+++ b/app/services/holding.py
@@ -101,9 +101,11 @@ def get_holding_summary(request: HoldingRequest) -> dict[str, any]:
         connection=engine,
     )["max"].item()
 
+    side = shares.sign()
+
     n_days = len(df_wide["date"].unique())
 
-    total_return = stk["cummulative_return"].last() * 100
+    total_return = side * (stk["cummulative_return"].last() * 100)
     total_return_rf = df_wide["cummulative_return_rf"].last() * 100
     total_return_bmk = df_wide["cummulative_return_bmk"].last() * 100
 
@@ -118,8 +120,8 @@ def get_holding_summary(request: HoldingRequest) -> dict[str, any]:
     price = stk["price"].last()
     value = shares * price
     volatility = stk["return"].std() * (n_days**0.5) * 100
-    dividends = stk["dividends"].sum()
-    dividends_per_share = stk["dividends_per_share"].sum()
+    dividends = side * (stk["dividends"].sum())
+    dividends_per_share = side * (stk["dividends_per_share"].sum)
     dividend_yield = dividends / value * 100
 
     min_date = stk["date"].min()


### PR DESCRIPTION
Multiplying the total_return, dividends and dividends_per_share by the sign of the shares (side) to deal with shorts. Value should already be correct because it has shares in the calculation. Following the logic talked about with Andrew about calculating returns and other metrics after the cummalitive return calculation so the math is correct. 