### PR TITLE
adding short logic to holding time series as well.

### DIFF
--- a/app/services/holding.py
+++ b/app/services/holding.py
@@ -176,20 +176,22 @@ def get_holding_time_series(request: HoldingRequest) -> dict[str, any]:
             ).cast(pl.Float64),
         )
         .sort("date", "ticker")
-        .with_columns(
-            pl.col("return").add(1).cum_prod().sub(1).alias("cummulative_return")
-        )
-        .select(
-            "date",
-            "weight",
-            "price",
-            "shares",
-            "value",
-            "return",
-            "cummulative_return",
-            "dividends",
-            "dividends_per_share",
-        )
+    )
+
+    side = stk["shares"].sign().last()
+
+    stk = stk.with_columns(
+        pl.col("return").add(1).cum_prod().sub(1).mul(side).alias("cummulative_return")
+    ).select(
+        "date",
+        "weight",
+        "price",
+        "shares",
+        "value",
+        "return",
+        "cummulative_return",
+        "dividends",
+        "dividends_per_share",
     )
 
     bmk = (


### PR DESCRIPTION
Needed to multiply cumulative returns in the holding time series by the side as well. Fast API shows that now both holding summary and holding time series return negative returns for short positions. 

This will fix the charts. 